### PR TITLE
データベース内の商品の詳細を返すように変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,4 @@ jobs:
        push: true
        tags: ${{ steps.meta.outputs.tags }}
        labels: ${{ steps.meta.outputs.labels }}
+       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,4 +44,3 @@ jobs:
        push: true
        tags: ${{ steps.meta.outputs.tags }}
        labels: ${{ steps.meta.outputs.labels }}
-       


### PR DESCRIPTION
## What
### STEP3: 出品APIを作る
#### 5. 商品の詳細を返す
データベース内の商品でなく、JSONファイル内の商品を返していたので、修正した。
これにより、ブラウザで http://127.0.0.1:9000/items/1 等アクセスすると、データベース内のアイテムが表示される

### STEP6: CIを使ってDocker imageをBuildする
#### 3. アプリケーションをGitHub Actionsでビルドして、docker imageをregistryにupする
修正版のtagは0424とした。
ローカルでimageをpullする
`docker pull ghcr.io/ayana326/mercari-build-training:date0424`
実行する
`docker run -d -p 9000:9000 ghcr.io/ayana326/mercari-build-training:date0424`
`docker run ghcr.io/ayana326/mercari-build-training:date0424`
ブラウザで http://127.0.0.1:9000/items にアクセスすると、データベースの中身が表示される

## CHECKS :warning:

Please make sure you are aware of the following.

- [ ] **The changes in this PR doesn't have private information
